### PR TITLE
Polo

### DIFF
--- a/aws_iot_mqtt_client.py
+++ b/aws_iot_mqtt_client.py
@@ -45,7 +45,7 @@ On python side, for feedback to Arduino:
 'SD' - shadowDelete
 *Incoming string starting with the corresponding lower case letter represents the corresponding requests
 '''
-# marco
+# macros
 ###################################
 MAX_CONN_TIME = 10
 EXIT_TIME_OUT = 25


### PR DESCRIPTION
I guess someone meant to say `macro` instead of `marco`. I think `macros` is more consistent with the rest of the comments.
