### PR TITLE
Fixed examples to avoid the serial1 communication latency problem

### DIFF
--- a/AWS-IoT-Arduino-Yun-Library/aws_iot_version.h
+++ b/AWS-IoT-Arduino-Yun-Library/aws_iot_version.h
@@ -18,7 +18,7 @@
 
 #define VERSION_MAJOR 2
 #define VERSION_MINOR 1
-#define VERSION_PATCH 1
+#define VERSION_PATCH 2
 #define VERSION_TAG ""
 
 #endif

--- a/AWS-IoT-Arduino-Yun-Library/examples/ThermostatSimulatorDevice/ThermostatSimulatorDevice.ino
+++ b/AWS-IoT-Arduino-Yun-Library/examples/ThermostatSimulatorDevice/ThermostatSimulatorDevice.ino
@@ -41,6 +41,7 @@ bool print_log(const char* src, int code) {
     Serial.println(code);
     ret = false;
   }
+  Serial.flush();
   return ret;
 }
 

--- a/AWS-IoT-Arduino-Yun-Library/examples/ThingShadowEcho/ThingShadowEcho.ino
+++ b/AWS-IoT-Arduino-Yun-Library/examples/ThingShadowEcho/ThingShadowEcho.ino
@@ -38,6 +38,7 @@ bool print_log(const char* src, int code) {
     Serial.println(code);
     ret = false;
   }
+  Serial.flush();
   return ret;
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+#2.1.2 (June 22th, 2016)
+Features:  
+
+N/A  
+
+Bugfixes.Improvements:  
+
+* Fixed issue in the examples related to serial1 communication latency flushing the serial port in the loggin function.
+
 #2.1.1 (May 23th, 2016)  
 Features:  
 


### PR DESCRIPTION
Resolves #16 related to serial1 communication latency flushing the serial port in the logging function.
