### PR TITLE
Correct file name in AWSIotArduinoYunSetupEnvironment.sh usage response

### DIFF
--- a/AWSIoTArduinoYunSetupEnvironment.sh
+++ b/AWSIoTArduinoYunSetupEnvironment.sh
@@ -3,7 +3,7 @@
 
 # Args check
 if {$argc!= 3} {
-    send_user "usage: ./AWSIoTArduinoYunScp.sh <Board IP> <UserName> <Board Password>\n"
+    send_user "usage: ./AWSIoTArduinoYunSetupEnvironment.sh <Board IP> <UserName> <Board Password>\n"
     exit
 }
 


### PR DESCRIPTION
To avoid confusion, minor clean up of wrong file name in usage response for SetupEnvironment script.
